### PR TITLE
Wait next frame on playin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cher-ami/transitions-manager",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cher-ami/transitions-manager",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@solid-js/signal": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cher-ami/transitions-manager",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "author": "Willy Brauner & cher-ami",

--- a/src/TransitionsManager.ts
+++ b/src/TransitionsManager.ts
@@ -76,7 +76,8 @@ export class TransitionsManager {
 
     this.log("playIn")
     this.playInDeferred = deferredPromise<void>()
-    this.playStateSignal.dispatch("play-in")
+    // wait next frame to be sure the component is mounted and listen playStateSignal
+    setTimeout(()=> this.playStateSignal.dispatch("play-in"), 0)
     return this.playInDeferred.promise
   }
 


### PR DESCRIPTION
Problem: 

The parent component mount the component using a `TransitionsManager` instance : 

````jsx
const App = () => {
  const childIsMount = useIsMount(Child.transitionManager);
  return {childIsMount && <Child />}
}
````

The child can listen `playStateSignal` only on after beeing mounted with `usePlayIn` hook.

````jsx
usePlayIn(WrongAnswerPopin.TransitionsManager, async (done) => {
    // here, the "playStateSignal" handler content
    // this code is executed when the manager dispatch "play-in" state
  })
````

But sometimes the component start to listening after the `TransitionManager` instance dispatch "play-in" state. The child didn't catch this first dispatch and playIn is never fired.

This MR just Add a "next frame" hake in order to wait the child component will be rendered BEFORE the "play-in" state will be dispatched by the manager.








